### PR TITLE
Refactor/zoom frame

### DIFF
--- a/ultratrace/__main__.py
+++ b/ultratrace/__main__.py
@@ -223,7 +223,7 @@ class App(ThemedTk):
 		self.getWinSize()
 		self.alignBottomRight(self.oldwidth-self.leftwidth)
 		if self.Dicom.zframe.image:
-			self.Dicom.zframe.setImage(self.Dicom.zframe.image)
+			self.Dicom.zframe.set_image(self.Dicom.zframe.image)
 
 	def alignBottomLeftWrapper(self, event=None):
 		if self.isResizing: return
@@ -246,7 +246,7 @@ class App(ThemedTk):
 		if event == None or event.widget == self:
 			self.alignBottomRight(self.winfo_width() - self.leftwidth)
 			if self.Dicom.zframe.image:
-				self.Dicom.zframe.setImage(self.Dicom.zframe.image)
+				self.Dicom.zframe.set_image(self.Dicom.zframe.image)
 		self.isResizing = False
 	def alignBottomRight(self,x):
 		''' '''
@@ -416,7 +416,7 @@ class App(ThemedTk):
 			#resize dicom image
 			png_loc = self.Data.getPreprocessedDicom(self.frame)
 			image = PIL.Image.open( png_loc )
-			self.Dicom.zframe.setImage(image)
+			self.Dicom.zframe.set_image(image)
 			# x = self.Dicom.zframe.width
 			x = self.winfo_width() - self.LEFT.winfo_width()
 			# y = self.Dicom.zframe.height
@@ -455,8 +455,8 @@ class App(ThemedTk):
 				lastClick = self.click
 				thisClick = (event.x, event.y)
 				# enforce minimum distance b/w new crosshairs
-				dx = abs(thisClick[0] - lastClick[0]) / self.Dicom.zframe.imgscale
-				dy = abs(thisClick[1] - lastClick[1]) / self.Dicom.zframe.imgscale
+				dx = abs(thisClick[0] - lastClick[0]) / self.Dicom.zframe.get_zoom_scale()
+				dy = abs(thisClick[1] - lastClick[1]) / self.Dicom.zframe.get_zoom_scale()
 				if dx > util.CROSSHAIR_DRAG_BUFFER or dy > util.CROSSHAIR_DRAG_BUFFER:
 					self.click = thisClick
 					ch = self.Trace.add( *self.click )

--- a/ultratrace/modules/dicom.py
+++ b/ultratrace/modules/dicom.py
@@ -35,7 +35,7 @@ class Dicom(Module):
             self.reader = None
 
             # zoom frame (contains our tracing canvas)
-            self.zframe = ZoomFrame(self.app.RIGHT, 1.3, app)
+            self.zframe = ZoomFrame(self.app.RIGHT, app)
 
             # reset zoom button
             self.zoomResetBtn = Button(self.app.LEFT, text='Reset image', command=self.zoomReset, takefocus=0)#, pady=7 )
@@ -54,9 +54,6 @@ class Dicom(Module):
         if self.isLoaded():
             # creates a new canvas object and we redraw everything to it
             self.zframe.resetCanvas()
-            # self.zframe.canvas.bind('<Button-1>', self.app.onClickZoom )
-            # self.zframe.canvas.bind('<ButtonRelease-1>', self.app.onRelease )
-            # self.zframe.canvas.bind('<Motion>', self.app.onMotion )
 
             # we want to go here only after a button press
             if fromButton: self.app.framesUpdate()
@@ -66,7 +63,7 @@ class Dicom(Module):
         change the image on the zoom frame
         '''
         if self.reader and self.reader.loaded:
-            self.zframe.setImage(self.reader.getFrame(_frame or self.app.frame))
+            self.zframe.set_image(self.reader.getFrame(_frame or self.app.frame))
 
     def load(self, event=None):
         '''
@@ -163,6 +160,7 @@ class Dicom(Module):
         self.app.framesNextBtn.grid(  row=0, column=3 )
         self.zoomResetBtn.grid( row=7 )
         self.app.Control.grid()
+        self.zframe.grid()
 
     def grid_remove(self):
         '''
@@ -175,3 +173,5 @@ class Dicom(Module):
         self.app.framesNextBtn.grid_remove()
         self.zoomResetBtn.grid_remove()
         self.app.Control.grid_remove()
+        self.zframe.grid_remove()
+

--- a/ultratrace/modules/search.py
+++ b/ultratrace/modules/search.py
@@ -60,7 +60,7 @@ class Search(Module):
             if tg:
                 grid = self.app.TextGrid.fromFile(tg)
                 if grid is None:
-                    return
+                    continue
                 for tier in grid:
                     if TextGrid.isIntervalTier(tier):
                         for el in tier:

--- a/ultratrace/modules/search.py
+++ b/ultratrace/modules/search.py
@@ -59,6 +59,8 @@ class Search(Module):
             tg = self.app.Data.checkFileLevel('.TextGrid', f)
             if tg:
                 grid = self.app.TextGrid.fromFile(tg)
+                if grid is None:
+                    return
                 for tier in grid:
                     if TextGrid.isIntervalTier(tier):
                         for el in tier:

--- a/ultratrace/modules/textgrid.py
+++ b/ultratrace/modules/textgrid.py
@@ -224,7 +224,7 @@ class TextGrid(Module):
             sentenceTier = IntervalTier("text")
             sentenceTier.add(minTime, maxTime, "text")
             self.TextGrid.tiers.append(sentenceTier)
-            fname = self.app.Data.unrelativize(self.app.Data.getCurrentFileName() + '.TextGrid')
+            fname = self.app.Data.unrelativize(self.app.Data.getCurrentFilename() + '.TextGrid')
             self.app.Data.setFileLevel('.TextGrid', fname)
         names = self.TextGrid.getNames()
         for i, n in enumerate(names):

--- a/ultratrace/widgets/crosshairs.py
+++ b/ultratrace/widgets/crosshairs.py
@@ -62,13 +62,13 @@ class Crosshairs:
         canvas coords -> absolute coords
         absolute coords are % along each axis (e.g. center of image = [.5,.5])
         '''
-        # x = (self.trueX - self.zframe.panX) / self.zframe.imgscale
-        # y = (self.trueY - self.zframe.panY) / self.zframe.imgscale
+        # x = (self.trueX - self.zframe.panX) / self.zframe.get_zoom_scale()
+        # y = (self.trueY - self.zframe.panY) / self.zframe.get_zoom_scale()
         # return x,y
-        truex = (x-self.zframe.panX)/(self.zframe.width*self.zframe.imgscale)
-        truey = (y-self.zframe.panY)/(self.zframe.height*self.zframe.imgscale)
-        # truex = (x-self.zframe.panX)/self.zframe.imgscale
-        # truey = (y-self.zframe.panY)/self.zframe.imgscale
+        truex = (x-self.zframe.panX)/(self.zframe.width*self.zframe.get_zoom_scale())
+        truey = (y-self.zframe.panY)/(self.zframe.height*self.zframe.get_zoom_scale())
+        # truex = (x-self.zframe.panX)/self.zframe.get_zoom_scale()
+        # truey = (y-self.zframe.panY)/self.zframe.get_zoom_scale()
         debug(truex, truey)
         return truex, truey
 
@@ -77,10 +77,10 @@ class Crosshairs:
         absolute coords -> canvas coords
         absolute coords are % along each axis (e.g. center of image = [.5,.5])
         '''
-        # x = (_x * self.zframe.imgscale) + self.zframe.panX
-        # y = (_y * self.zframe.imgscale) + self.zframe.panY
-        x = truex * self.zframe.width * self.zframe.imgscale + self.zframe.panX
-        y = truey * self.zframe.height * self.zframe.imgscale + self.zframe.panY
+        # x = (_x * self.zframe.get_zoom_scale()) + self.zframe.panX
+        # y = (_y * self.zframe.get_zoom_scale()) + self.zframe.panY
+        x = truex * self.zframe.width * self.zframe.get_zoom_scale() + self.zframe.panX
+        y = truey * self.zframe.height * self.zframe.get_zoom_scale() + self.zframe.panY
         return x, y
 
     def transformCoords(self, x, y):
@@ -91,7 +91,7 @@ class Crosshairs:
 
     def transformLength(self, l):
         ''' transforms a length by our current zoom-amount '''
-        return l * self.zframe.imgscale
+        return l * self.zframe.get_zoom_scale()
 
     def getDistance(self, click):
         ''' calculates the distance from centerpoint to a click event '''

--- a/ultratrace/widgets/zoom_frame.py
+++ b/ultratrace/widgets/zoom_frame.py
@@ -65,10 +65,10 @@ class ZoomFrame(tk.Frame):
         scale = self.get_zoom_scale()
 
         self.container = self.canvas.create_rectangle(
-                0,#-width/2,
-                0,#-height/2,
-                width,#width/2,
-                height,#height/2,
+                0,
+                0,
+                width,
+                height,
                 width=0,
                 tags='delendum')
         self.canvas.scale('all', 0, 0, scale, scale)

--- a/ultratrace/widgets/zoom_frame.py
+++ b/ultratrace/widgets/zoom_frame.py
@@ -94,12 +94,12 @@ class ZoomFrame(tk.Frame):
             self.zoom_out()
 
     def zoom_in(self):
-        if self.image is not None and self.zoom > self.MIN_ZOOM:
+        if self.image is not None and self.zoom < self.MAX_ZOOM:
             self.zoom += 1
             self.show_image()
 
     def zoom_out(self):
-        if self.image is not None and self.zoom < self.MAX_ZOOM:
+        if self.image is not None and self.zoom > self.MIN_ZOOM:
             self.zoom -= 1
             self.show_image()
 

--- a/ultratrace/widgets/zoom_frame.py
+++ b/ultratrace/widgets/zoom_frame.py
@@ -1,158 +1,122 @@
-from tkinter import Canvas, Frame
-from PIL import ImageTk # pillow
+import tkinter as tk
+from PIL import ImageTk
 
 from .rect_tracker import RectTracker
 
-class ZoomFrame(Frame):
-    '''
-    Wrapper for a Tk Frame() object that includes zooming and panning functionality.
-    This code is inspired by the answer from https://stackoverflow.com/users/7550928/foo-bar
-    at https://stackoverflow.com/questions/41656176/tkinter-canvas-zoom-move-pan ...
-    Could probably be cleaned up and slimmed down
-    '''
-    def __init__(self, master, delta, app):
-        Frame.__init__(self, master)
+class ZoomFrame(tk.Frame):
+    WIDGET_WIDTH = 800
+    WIDGET_HEIGHT = 600
+    MIN_ZOOM = -5
+    MAX_ZOOM = 5
+    SCALE_FACTOR = 1.3
+    def __init__(self, master, app):
+
+        super().__init__(master)
+
         self.app = app
-        self.delta = delta
-        self.maxZoom = 5
-        #self.resetCanvas(master)
 
-        self.canvas_width = 800
-        self.width = 0
-        self.canvas_height = 600
-        self.height = 0
+        self.canvas = tk.Canvas(
+                master,
+                bg='grey',
+                width=self.WIDGET_WIDTH,
+                height=self.WIDGET_HEIGHT,
+                highlightthickness=0)
+        self.canvas.update() # tkinter needs this or else it won't render the image
+
+        self.canvas.bind('<Control-Button-1>', self.pan_start)
+        self.canvas.bind('<Control-B1-Motion>', self.pan)
+        self.canvas.bind('<MouseWheel>', self.zoom) # Windows / MacOS
+        self.canvas.bind('<Button-4>', self.zoom_in) # Linux scroll up
+        self.canvas.bind('<Button-5>', self.zoom_out) # Linux scroll down
+        self.canvas.bind('<Button-1>', self.app.onClickZoom)
+        self.canvas.bind('<Motion>', self.app.onMotion)
+
+        self.app.bind('<Command-equal>', self.zoom_in)
+        self.app.bind('<Command-minus>', self.zoom_out)
+
+        RectTracker(self.canvas).autodraw(outline='blue')
+
         self.shown = False
-        self.aspect_ratio = 4.0/3.0
 
-        self.canvas = Canvas( master,  bg='grey', width=self.canvas_width, height=self.canvas_height, highlightthickness=0 )
-        self.canvas.grid(row=0, column=0, sticky='news')
-        self.canvas.update() # do i need
-        rect = RectTracker(self.canvas)
-        rect.autodraw(outline='blue')
+        self.reset_canvas()
 
-        # self.master.rowconfigure(0, weight=1) # do i need
-        # self.master.columnconfigure(0, weight=1) # do i need
+    def reset_canvas(self):
 
-        # self.canvas.bind('<Configure>', self.showImage ) # on canvas resize events
-        self.canvas.bind('<Control-Button-1>', self.moveFrom )
-        self.canvas.bind('<Control-B1-Motion>', self.moveTo )
-        self.canvas.bind('<MouseWheel>', self.wheel ) # Windows & Linux
-        self.canvas.bind('<Button-4>', self.wheel )   # Linux scroll up
-        self.canvas.bind('<Button-5>', self.wheel )   # Linux scroll down
-
-        self.resetCanvas()
-
-        self.canvas.bind('<Button-1>', self.app.onClickZoom )
-        self.canvas.bind('<Motion>', self.app.onMotion )
-
-        self.app.bind('<Command-equal>', self.wheel )
-        self.app.bind('<Command-minus>', self.wheel )
-
-    def resetCanvas(self):
-        self.canvas_width = 800
-        self.canvas_height = 600
-
-        # self.canvas = Canvas( master,  bg='grey', width=self.canvas_width, height=self.canvas_height, highlightthickness=0 )
-        # self.canvas.grid(row=0, column=0, sticky='news')
-        # self.canvas.update() # do i need
-
-        # self.master.rowconfigure(0, weight=1) # do i need
-        # self.master.columnconfigure(0, weight=1) # do i need
-        #
-        # self.canvas.bind('<Configure>', self.showImage ) # on canvas resize events
-        # self.canvas.bind('<Control-Button-1>', self.moveFrom )
-        # self.canvas.bind('<Control-B1-Motion>', self.moveTo )
-        # self.canvas.bind('<MouseWheel>', self.wheel ) # Windows & Linux FIXME
-        # self.canvas.bind('<Button-4>', self.wheel )   # Linux scroll up
-        # self.canvas.bind('<Button-5>', self.wheel )   # Linux scroll down
-
-        self.origX = self.canvas.xview()[0] - 1
-        self.origY = self.canvas.yview()[0] - 150
-
-        self.zoom = 0
-        self.imgscale = 1.0
         self.image = None
-        self.panStartX = 0
-        self.panStartY = 0
-        self.panX = 0
-        self.panY = 0
+        self.zoom = 0
+        self.pan_start_x = 0
+        self.pan_start_y = 0
+        self.pan_x = 0
+        self.pan_y = 0
 
-    def resetImageDimensions(self):
-        self.width = 0
-        self.height = 0
-        self.aspect_ratio = 1
-
-    def setImage(self, image): # expect an Image() instance
+    def set_image(self, image):
         self.image = image
-        if self.width == 0:
-            self.width, self.height = self.image.size
-            self.aspect_ratio = self.width/self.height
-        win_width = self.app.RIGHT.winfo_width()
-        asp_height = round(win_width / self.aspect_ratio)
-        win_height = self.app.RIGHT.winfo_height()
-        asp_width = round(win_height * self.aspect_ratio)
-        if asp_height > win_height:
-            self.height = win_height
-            self.width = asp_width
-        else:
-            self.height = asp_height
-            self.width = win_width
-        self.showImage()
+        self.show_image()
 
-    def showImage(self, event=None):
-        # even if we're not showing a new frame, we want to remove the old one
+    def get_zoom_scale(self):
+        return self.ZOOM_FACTOR ** self.zoom
+
+    def show_image(self, event=None):
         self.canvas.delete('delendum')
-        if self.image != None:
-            self.container = self.canvas.create_rectangle(0,0,self.width,self.height,width=0, tags='delendum')
-            self.canvas.scale('all', 0, 0, self.imgscale, self.imgscale)
-            self.canvas.move('all', self.panX, self.panY)
-            bbox = self.canvas.bbox(self.container)
-            image = self.image.resize((bbox[2] - bbox[0], bbox[3] - bbox[1]))
-            imagetk = ImageTk.PhotoImage(image)
-            image = self.canvas.create_image(bbox[0], bbox[1], anchor='nw', image=imagetk, tags='delendum')
-            self.canvas.lower(image)
-            self.canvas.imagetk = imagetk
-            self.shown = True
-            self.app.Trace.update()
+        if self.image is None:
+            return
 
-    def wheel(self, event):
-        if self.image != None:
-            if event.keysym == 'equal' or event.keysym == 'minus': #what is this for?
-                x = self.canvas_width/2
-                y = self.canvas_height/2
-            else:                                                   #do these vars get used?
-                x = self.canvas.canvasx(event.x)
-                y = self.canvas.canvasy(event.y)
+        width, height = self.image.size
+        scale = self.get_zoom_scale()
 
-            # Respond to Linux (event.num) or Windows (event.delta) wheel event
-            if event.num == 5 or event.delta < 0 or event.keysym == 'minus':  # zoom out
-                if self.zoom < self.maxZoom:
-                    self.zoom += 1
-                    self.imgscale /= self.delta
+        self.container = self.canvas.create_rectangle(
+                0,#-width/2,
+                0,#-height/2,
+                width,#width/2,
+                height,#height/2,
+                width=0,
+                tags='delendum')
+        self.canvas.scale('all', 0, 0, scale, scale)
+        self.canvas.move('all', self.pan_x, self.pan_y)
 
-            elif event.num == 4 or event.delta > 0 or event.keysym == 'equal':  # zoom in
-                if self.zoom > self.maxZoom * -1:
-                    self.zoom -= 1
-                    self.imgscale *= self.delta
+        x0, y0, x1, y1 = self.canvas.bbox(self.container)
+        scaled_image = self.image.resize((x1 - x0, y1 - y0))
 
-            bbox = self.canvas.coords(self.container)
-            self.panX = bbox[0]
-            self.panY = bbox[1]
-            self.showImage()
+        # save a reference so that python doesn't garbage collect it
+        self.image_tk = ImageTk.PhotoImage(scaled_image)
+        self.canvas.create_image(
+                x0,
+                y0,
+                anchor='nw',
+                image=self.image_tk,
+                tags='delendum')
+        self.canvas.lower('delendum')
 
-    def scrollY(self, *args, **kwargs):
-        self.canvas.yview(*args, **kwargs)
-        self.showImage()
+    def zoom(self, event):
+        if event.delta > 0:
+            self.zoom_in()
+        else:
+            self.zoom_out()
 
-    def moveFrom(self, event):
-        self.panStartX = event.x
-        self.panStartY = event.y
+    def zoom_in(self):
+        if self.image is not None and self.zoom > self.MIN_ZOOM:
+            self.zoom += 1
+            self.show_image()
 
-    def moveTo(self, event):
-        dx = event.x - self.panStartX
-        dy = event.y - self.panStartY
-        self.panStartX = event.x
-        self.panStartY = event.y
-        self.panX += dx
-        self.panY += dy
-        self.showImage()
+    def zoom_out(self):
+        if self.image is not None and self.zoom < self.MAX_ZOOM:
+            self.zoom -= 1
+            self.show_image()
+
+    def pan_start(self, event):
+        self.pan_start_x = event.x
+        self.pan_start_y = event.y
+
+    def pan(self, event):
+        self.pan_x += event.x - self.pan_start_x
+        self.pan_y += event.y - self.pan_start_y
+        self.pan_start_x = event.x
+        self.pan_start_y = event.y
+        self.show_image()
+
+    def grid(self):
+        self.canvas.grid(row=0, column=0, sticky='news')
+
+    def grid_remove(self):
+        self.canvas.grid_remove()
+


### PR DESCRIPTION
This patch simplifies some of the internal structure of the `ZoomFrame` widget towards an ultimate goal of generally refactoring our widgets.

In particular, I think we should move away from modifying internal state of classes directly, and instead rely on small functions that perform single tasks  (see, for example, splitting `ZoomFrame::wheel` into `ZoomFrame::zoom{,in,out}`), as well as only maintaining the minimal amount of state that cannot be derived.

If you guys have a chance, could you take a look at this PR and just make sure it still works for you?  Ultimately, we should be also moving towards a unit-testing framework, as that will enable us to make these larger refactoring changes without worrying about breaking compatibility.