### PR TITLE
Add setup.py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if which brew; then
+if which brew &> /dev/null; then
     brew install portaudio
 else
     echo "Homebrew is not on your PATH. Is it installed?"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if which brew; then
+    brew install portaudio
+else
+    echo "Homebrew is not on your PATH. Is it installed?"
+    echo "Other package managers are not currently supported"
+    exit 1
+fi

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,3 +5,9 @@ import nox
 def format(session):
     session.install("black")
     session.run("black", "--check", "ultratrace2")
+
+
+@nox.session
+def install(session):
+    """Install ultratrace2. Assumes required system libraries are installed."""
+    session.install(".")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_namespace_packages
+
+
+def get_requirements(path):
+    with open(path) as f:
+        return list(filter(lambda s: len(s) > 0, (get_requirement(l) for l in f)))
+
+
+def get_requirement(line):
+    r, *_ = line.split("#")
+    return r.strip().split()
+
+
+setup(
+    name="ultratrace",
+    author="Jonathan Washington",
+    author_email="jwashin1@swarthmore.edu",
+    version="0.0.1",
+    packages=find_namespace_packages(
+        include=["ultratrace2.*"], exclude=["ultratrace.*"]
+    ),
+    description="A tool for manually annotating ultrasound tongue imaging (UTI) data",
+    install_requires=get_requirements("requirements.txt"),
+    extras_require={"dev": ["flake8", "black", "mypy", "pytest"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,13 @@ setup(
     ),
     description="A tool for manually annotating ultrasound tongue imaging (UTI) data",
     install_requires=get_requirements("requirements.txt"),
-    extras_require={"dev": ["flake8", "black", "mypy", "pytest"]},
+    extras_require={
+        "dev": [
+            "flake8",
+            "black",
+            "mypy",
+            "pytest",
+            "numpy-stubs @ git+https://github.com/numpy/numpy-stubs.git@master",
+        ]
+    },
 )


### PR DESCRIPTION
Added an install script and a setup.py to faciliate the installation
process. The install script is very rudimentary; it tries to use
Homebrew to install 'portaudio' and gives up if Homebrew is not
installed.

The setup.py file will allow the user to install using `pip`. To build
from source, the user first runs `install.sh` then `pip install .`.
Optionally, the user can pass `--editable` to `pip install` so that
changes to .py files do not require another invocation of install to
have the most up-to-date verison locally.