### PR TITLE
Add ultratrace2 entrypoint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if which brew &> /dev/null; then
-    brew install portaudio
+    brew install portaudio libmagic ffmpeg libav
 else
     echo "Homebrew is not on your PATH. Is it installed?"
     echo "Other package managers are not currently supported"

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ setup(
     ),
     description="A tool for manually annotating ultrasound tongue imaging (UTI) data",
     install_requires=get_requirements("requirements.txt"),
+    entry_points={
+        "console_scripts": [
+            "ultratrace2 = ultratrace2.__main__:main"
+        ]
+    },
     extras_require={
         "dev": [
             "flake8",

--- a/ultratrace2/__main__.py
+++ b/ultratrace2/__main__.py
@@ -5,8 +5,8 @@ from .app import initialize_app
 
 logging.basicConfig(level=logging.DEBUG)
 
-if __name__ == "__main__":
 
+def main():
     parser = argparse.ArgumentParser()
 
     # noqa: E128
@@ -57,3 +57,7 @@ if __name__ == "__main__":
 
     app = initialize_app(args)
     app.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add and entrypoint console script to `setup.py`. Once installed, the user can invoke the program as follows:
```
(ultratrace) ➜  ultratrace git:(entrypoint) ultratrace2 -h
usage: ultratrace2 [-h] [--no-audio] [--no-dicom] [--no-textgrid]
                   [--no-spectrogram] [--no-video] [--theme THEME]
                   [--max-undo-memory MAX_UNDO_MEMORY]
                   path

positional arguments:
  path                  path (unique to a participant) where subdirectories
                        contain raw data

optional arguments:
  -h, --help            show this help message and exit
  --no-audio            don't try to load the audio widget
  --no-dicom            don't try to load the dicom widget
  --no-textgrid         don't try to load the textgrid widget
  --no-spectrogram      don't try to load the spectrogram widget
  --no-video            don't try to load the video widget
  --theme THEME         TtkTheme to use for application
  --max-undo-memory MAX_UNDO_MEMORY
                        number of operations to remember in the UndoManager
(ultratrace) ➜  ultratrace git:(entrypoint)
```