### PR TITLE
Fix CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.9
+      - image: circleci/python:3.7.2
     steps:
       - checkout
+      - run: ./install.sh
       - run: sudo pip install nox
       - run: nox

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,15 @@
 
 if which brew &> /dev/null; then
     brew install portaudio libmagic ffmpeg libav
+elif which apt-get &> /dev/null; then
+    sudo apt-get update
+    sudo apt-get install \
+        portaudio19-dev libportaudio2 \
+        libmagic-dev \
+        ffmpeg \
+        libav-tools
 else
-    echo "Homebrew is not on your PATH. Is it installed?"
-    echo "Other package managers are not currently supported"
+    echo "Your package manager is not currently supported."
+    echo "Currently supported managers are: brew, apt."
     exit 1
 fi


### PR DESCRIPTION
CI runs are erroring because certain system libraries aren't installed. Install these libs before running tests.