### PR TITLE
Tests for xhair.py

### DIFF
--- a/ultratrace2/model/color.py
+++ b/ultratrace2/model/color.py
@@ -1,4 +1,5 @@
 import random
+from typing import Any
 
 PIXEL_MIN = 0
 PIXEL_MAX = 255
@@ -44,6 +45,11 @@ class Color:
 
     def __repr__(self) -> str:
         return f"Color(0x{self.r:02x},0x{self.g:02x},0x{self.b:02x})"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        return self.r == other.r and self.g == other.g and self.b == other.b
 
 
 def get_random_color() -> Color:

--- a/ultratrace2/model/tests/test_color.py
+++ b/ultratrace2/model/tests/test_color.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext
-from typing import Optional, Type, Union
+from typing import Any, Optional, Type, Union
 
 import pytest
 
@@ -38,3 +38,18 @@ def test_set_r(raw_value: int, expected: Union[int, Type[Exception]]):
             c.r = raw_value
     else:
         raise AssertionError()
+
+
+@pytest.mark.parametrize(
+    "color,other,should_be_equal",
+    [
+        (Color(0, 0, 0), Color(0, 0, 0), True),
+        (Color(0, 0, 1), Color(0, 0, 0), False),
+        (Color(0, 0, 0), "not a color", False),
+    ],
+)
+def test_color_eq(color: Color, other: Any, should_be_equal: bool):
+    if should_be_equal:
+        assert color == other
+    else:
+        assert color != other

--- a/ultratrace2/model/tests/test_xhair.py
+++ b/ultratrace2/model/tests/test_xhair.py
@@ -1,0 +1,52 @@
+import math
+
+import pytest
+
+from ..xhair import XHair
+from ..color import Color
+
+
+def _get_black() -> Color:
+    return Color(0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "p,q,expected",
+    [
+        (XHair(_get_black, 0, 0), XHair(_get_black, 1, 0), 1),
+        (XHair(_get_black, 0, 0), XHair(_get_black, 1, 1), 2),
+        (XHair(_get_black, math.inf, 0), XHair(_get_black, 0, 0), math.inf),
+    ],
+)
+def test_sq_dist_from(p: XHair, q: XHair, expected: float):
+    assert p.sq_dist_from(q) == q.sq_dist_from(p) == expected
+
+
+def test_get_color():
+    x = XHair(_get_black, 0, 0)
+    assert x.get_color() == Color(0, 0, 0)
+
+
+def test_get_color_with_mutation():
+    class ColorRef:
+        def __init__(self, initial_color: Color):
+            self._color = initial_color
+
+        def get_color(self) -> Color:
+            return self._color
+
+        def set_color(self, color: Color) -> None:
+            self._color = color
+
+    initial_color = Color(0, 0, 0)
+    final_color = Color(0, 100, 0)
+    ref = ColorRef(initial_color)
+
+    x = XHair(ref.get_color, 0, 0)
+    color_pre_set = x.get_color()
+    ref.set_color(final_color)
+    color_post_set = x.get_color()
+
+    assert color_pre_set == initial_color
+    assert color_post_set != color_pre_set
+    assert color_post_set == final_color

--- a/ultratrace2/model/trace.py
+++ b/ultratrace2/model/trace.py
@@ -17,7 +17,7 @@ class Trace:
     def __init__(self, name: str, color: Color):
         self.id: UUID = uuid4()
         self.is_visible: bool = True
-        self.xhairs: Dict[FileBundle, Dict[int, Set[XHair]]] = {}
+        self.xhairs: Dict["FileBundle", Dict[int, Set[XHair]]] = {}
         self.name = name
         self.color = color
 
@@ -45,12 +45,12 @@ class Trace:
     def hide(self) -> None:
         self.is_visible = False
 
-    def add_xhair(self, bundle: FileBundle, frame: int, x: float, y: float) -> None:
+    def add_xhair(self, bundle: "FileBundle", frame: int, x: float, y: float) -> None:
         if bundle not in self.xhairs:
             self.xhairs[bundle] = {}
         if frame not in self.xhairs[bundle]:
             self.xhairs[bundle][frame] = set()
-        xhair = XHair(self, x, y)
+        xhair = XHair(self.get_color, x, y)
         self.xhairs[bundle][frame].add(xhair)
 
 

--- a/ultratrace2/model/xhair.py
+++ b/ultratrace2/model/xhair.py
@@ -1,16 +1,14 @@
-from typing import Tuple, TYPE_CHECKING, Union
+from typing import Callable, Tuple, Union
 from uuid import uuid4
 
-if TYPE_CHECKING:
-    from .color import Color
-    from .trace import Trace
+from .color import Color
 
 
 class XHair:
-    def __init__(self, trace: Trace, x: float, y: float):
+    def __init__(self, color_factory: Callable[[], Color], x: float, y: float):
 
         self.id = uuid4()
-        self.trace = trace
+        self._color_factory = color_factory
         self.x = x
         self.y = y
 
@@ -50,4 +48,4 @@ class XHair:
         self.y = y
 
     def get_color(self) -> Color:
-        return self.trace.get_color()
+        return self._color_factory()


### PR DESCRIPTION
Lightly refactor XHair to take a color factory instead of a Trace. This
enables easier testing since we don't need to construct a full Trace
object to construct an XHair. It also fixes the confusing behavior where
you can pass a Trace into a XHair, but not add the XHair to the Trace's
set of XHairs.

Implemented some tests for XHair for the more involved methods.