### PR TITLE
Typecheck untyped functions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+check_untyped_defs=True
 
 [mypy-pytest,pytest.*]
 ignore_missing_imports=True

--- a/ultratrace2/gui/widgets/div.py
+++ b/ultratrace2/gui/widgets/div.py
@@ -8,5 +8,5 @@ class Div(tk.Frame):
     def grid(self, *args, **kwargs):
         super().grid(*args, **kwargs)
 
-    def grid_remove(self, *args, **kwargs):
-        super().grid_remove(*args, **kwargs)
+    def grid_remove(self):
+        super().grid_remove()

--- a/ultratrace2/gui/widgets/zoom_frame.py
+++ b/ultratrace2/gui/widgets/zoom_frame.py
@@ -142,5 +142,5 @@ class ZoomFrame(tk.Frame):
         self.canvas.grid(sticky="news", column=0, row=0, rowspan=2)
 
     def grid_remove(self):
-        super().grid_remove(self)
+        super().grid_remove()
         self.canvas.grid_remove()


### PR DESCRIPTION
Without this option, this would typecheck because `f` does not have a type annotation:
```python
def f(x):
    a: int = "a"
```